### PR TITLE
Replace `fs.realPathSync` with `fs.realPath` to prevent blocking the UI thread

### DIFF
--- a/lib/dalek.js
+++ b/lib/dalek.js
@@ -1,44 +1,45 @@
 /** @babel */
 
-import fs from 'fs'
-import path from 'path'
+const fs = require('fs')
+const path = require('path')
 
-export default {
-  enumerate () {
+module.exports = {
+  async enumerate () {
+    const resourcePath = atom.getLoadSettings().resourcePath
     if (atom.inDevMode()) {
       return []
     }
 
-    let paths = atom.packages.getAvailablePackagePaths()
-    let counts = paths.filter((packagePath) => {
-      if (packagePath.includes('app.asar')) {
-        return true
-      }
-
-      if (fs.realpathSync(packagePath) !== packagePath) {
-        return false
-      }
-
-      return true
-    }).map((packagePath) => {
-      return path.basename(packagePath)
-    }).reduce((counts, name) => {
-      if (counts[name]) {
-        counts[name] += 1
-      } else {
-        counts[name] = 1
-      }
-
-      return counts
-    }, {})
-
-    let names = []
-    for (let name of Object.keys(counts)) {
-      if (counts[name] > 1) {
-        names.push(name)
+    const paths = atom.packages.getAvailablePackagePaths()
+    const countsByPackageName = new Map()
+    for (let i = 0; i < paths.length; i++) {
+      const packagePath = paths[i]
+      const realPath = await this.realpath(packagePath)
+      if (packagePath.includes(resourcePath) || realPath === packagePath) {
+        const packageName = path.basename(packagePath)
+        const counts = countsByPackageName.get(packageName) || 0
+        countsByPackageName.set(packageName, counts + 1)
       }
     }
 
-    return names
+    const duplicatePackages = []
+    for (const [packageName, count] of countsByPackageName) {
+      if (count > 1) {
+        duplicatePackages.push(packageName)
+      }
+    }
+    return duplicatePackages
+  },
+
+  realpath (path) {
+    return new Promise((resolve, reject) => {
+      fs.realpath(path, function (error, realpath) {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(realpath)
+        }
+      })
+    })
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,13 +1,14 @@
 /** @babel */
 
-export default {
-  activate () {
-    atom.packages.onDidActivateInitialPackages(() => {
-      const dalek = require('./dalek')
-      const Grim = require('grim')
+const dalek = require('./dalek')
+const Grim = require('grim')
 
-      let duplicates = dalek.enumerate()
-      for (let duplicate of duplicates) {
+module.exports = {
+  activate () {
+    atom.packages.onDidActivateInitialPackages(async () => {
+      const duplicates = await dalek.enumerate()
+      for (let i = 0; i < duplicates.length; i++) {
+        const duplicate = duplicates[i]
         Grim.deprecate(
           `You have the core package "${duplicate}" installed as a community package. See https://github.com/atom/dalek for how this causes problems and instructions on how to correct the situation.`,
           { packageName: duplicate }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "keywords": [],
   "repository": "https://github.com/atom/dalek",
   "license": "MIT",
+  "atomTestRunner": "./test/runner",
   "engines": {
     "atom": ">=1.12.7 <2.0.0"
   },
@@ -13,6 +14,8 @@
     "grim": "^2.0.1"
   },
   "devDependencies": {
+    "atom-mocha-test-runner": "^1.0.0",
+    "sinon": "^2.0.0",
     "standard": "^8.6.0"
   },
   "standard": {

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,0 +1,2 @@
+const createRunner = require('atom-mocha-test-runner').createRunner
+module.exports = createRunner({testSuffixes: ['test.js']})


### PR DESCRIPTION
I have noticed dalek appears in the critical path during Atom startup, taking up `~ 20ms` and blocking subsequent tasks like tokenization, etc.:

![screen shot 2017-03-17 at 17 47 23](https://cloud.githubusercontent.com/assets/482957/24053583/ccdc6cda-0b39-11e7-9b34-78c1d077a6e1.png)

With this pull request we are restructuring the package to use asynchronous filesystem calls, thus minimizing the time spent in `dalek.enumerate`:

![screen shot 2017-03-17 at 17 49 04](https://cloud.githubusercontent.com/assets/482957/24053657/08c54e42-0b3a-11e7-9f6a-36de3488f2f1.png)

/cc: @lee-dohm 